### PR TITLE
Improve handling of 500 error statuses from Vend

### DIFF
--- a/src/ShoppinPal/Vend/Api/BaseApiAbstract.php
+++ b/src/ShoppinPal/Vend/Api/BaseApiAbstract.php
@@ -144,7 +144,12 @@ abstract class BaseApiAbstract
             return null;
         }
 
-        $resultData = json_decode($result->getResponseBody(), true);
+        if (500 == $result->getResponseCode()) {
+            // 500 errors return an HTML error page, which can't be decoded as JSON
+            $resultData = null;
+        } else {
+            $resultData = json_decode($result->getResponseBody(), true);
+        }
 
         if (empty($resultData)) {
             $exceptionClass = $this->getCommunicationExceptionClass();


### PR DESCRIPTION
Currently we don't throw an exception for 500 errors which return an HTML error page as a response.